### PR TITLE
Add support for size middleware

### DIFF
--- a/src/buildConfigFromModifiers.js
+++ b/src/buildConfigFromModifiers.js
@@ -1,4 +1,4 @@
-import { flip, inline, offset, shift, autoPlacement, arrow, hide } from "@floating-ui/dom";
+import { flip, inline, offset, shift, autoPlacement, arrow, size, hide } from "@floating-ui/dom";
 
 export const buildConfigFromModifiers = (modifiers) => {
 
@@ -43,6 +43,10 @@ export const buildConfigFromModifiers = (modifiers) => {
 
   if (keys.includes("hide")) {
     config.middleware.push(hide(getModifierArgument("hide")));
+  }
+  
+  if (keys.includes("size")) {
+    config.middleware.push(size(getModifierArgument("size")));
   }
 
   return config;

--- a/src/buildDirectiveConfigFromModifiers.js
+++ b/src/buildDirectiveConfigFromModifiers.js
@@ -1,4 +1,4 @@
-import { flip, inline, offset, shift, autoPlacement, arrow, hide } from "@floating-ui/dom";
+import { flip, inline, offset, shift, autoPlacement, arrow, size, hide } from "@floating-ui/dom";
 
 export const buildDirectiveConfigFromModifiers = (modifiers, settings) => {
   const config = {
@@ -54,6 +54,10 @@ export const buildDirectiveConfigFromModifiers = (modifiers, settings) => {
 
   if (modifiers.includes("hide")) {
     config.float.middleware.push(hide(settings["hide"]));
+  }
+  
+  if (modifiers.includes("size")) {
+    config.float.middleware.push(size(settings["size"]));
   }
 
   return config;


### PR DESCRIPTION
This simple PR adds support for the [Floating UI Size Middleware](https://floating-ui.com/docs/size). I've tested this and am able to use it as expected with this addition.

```
<div
    x-ref="dropdown"
    x-float.placement.bottom-end.flip.offset.size.teleport="{
        size: {
            apply({availableWidth, availableHeight, elements}) {
                // Do things with the data, e.g.
                Object.assign(elements.floating.style, {
                    maxWidth: `${availableWidth}px`,
                    maxHeight: `${availableHeight}px`,
                });
            },
        }
  }"
>
Some test content
</div>
```

This grabs the correct values and runs the apply function as expected.